### PR TITLE
Update library to use stdin and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ $ sort-keys <source>[ <destination>]
 ## Options
 ```bash
 -d, --deep      Deep sort all objects
-<source>        Source JSON file
-<destination>   (Optional) Destination file location. Will overwrite source if not provided.
+-s, --std      Use STDIN and STDOUT instead of files
+<source>        Source JSON file (if not using STDIN)
+<destination>   (Optional) Destination file location (if not using STDOUT). Will overwrite source if not provided.
 ```
 
 ## Examples

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"semicolons": "asNeeded",
+			"quoteStyle": "single"
+		}
+	}
+}

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+
 'use strict';
-const { readFileSync, writeFileSync } = require('fs')
+
+const { createReadStream, createWriteStream } = require('fs')
 const { resolve } = require('path')
 const meow = require('meow');
 const sort = require('sort-keys');
@@ -11,6 +13,11 @@ const cli = meow({
       type: 'boolean',
       alias: 'd',
       default: false
+    },
+    std: {
+      type: 'boolean',
+      alias: 's',
+      default: false
     }
   }
 }, `
@@ -18,32 +25,75 @@ const cli = meow({
 	  $ sort-keys <source>[ <destination>]
 	Options
 	  -d, --deep    Deep sort all objects
-	<source>        Source JSON file
-	<destination>   (Optional) Destination file location. Will overwrite source if not provided.
+    -s, --std.    Use STDIN and STDOUT instead of files
+	<source>        Source JSON file (if not using STDIN)
+	<destination>   (Optional) Destination file location (if not using STDOUT). Will overwrite source if not provided.
 	Examples
 	  Sort all keys in a JSON file all .png files in src folder into dist except src/goat.png
 	  $ sort-keys example.json --deep
+
+    Sort all keys in a JSON file using STDIN and STDOUT
+    $ cat example.json | sort-keys -s --deep | sponge example.json
 `);
 
+const checkSuffix = (filename) => 
+  !filename.endsWith('.json') ? `${filename}.json` : filename
+
+const getSource = (cli) => {
+  if (!!cli.flags.std) {
+    return process.stdin
+  }
+
+  let [ source ] = cli.input
+
+  source = resolve(process.cwd(), checkSuffix(source))
+
+  return createReadStream(source, { encoding: "utf-8" })
+}
+
+const getDestination = (cli) => {
+  if (!!cli.flags.std) {
+    return process.stdout
+  }
+
+  let [ _, destination ] = cli.input
+
+  destination = resolve(process.cwd(), checkSuffix(destination))
+
+  return createWriteStream(destination, { encoding: "utf-8" })
+}
+
+const readJSON = (stream) => {
+  let data = []
+
+  stream.setEncoding("utf-8")
+
+  return new Promise((resolve, reject) => {
+    stream.on("error", reject)
+
+    stream.on("data", (chunk) => data.push(chunk))
+
+    stream.on("end", () => {
+      try {
+        resolve(JSON.parse(data.join("")))
+      }
+      catch(e) {
+        reject(e)
+      }
+    })
+  })
+}
+  
 (async () => {
   try {
-    let [ source, destination ] = cli.input
-
-    if (!source.endsWith('.json')) source = `${source}.json`
-    source = resolve(process.cwd(), source)
-
-    if (!destination) destination = source
-    else {
-      if (!destination.endsWith('.json')) destination = `${destination}.json`
-      destination = resolve(process.cwd(), destination)
-    }
-
-    const obj = JSON.parse(readFileSync(source, 'utf8'));
+    const source = getSource(cli)
+    const obj = await readJSON(source)
     const sorted = sort(obj, {
       deep: !!cli.flags.deep,
     });
 
-    writeFileSync(destination, JSON.stringify(sorted, null, 2))
+    const destination = getDestination(cli)
+    destination.write(JSON.stringify(sorted, null, 2))
   } catch (error) {
     if (error.name === 'SortKeysError') {
       console.error(error.message);

--- a/cli.js
+++ b/cli.js
@@ -1,31 +1,31 @@
 #!/usr/bin/env node
 
-'use strict';
+const { createReadStream, createWriteStream } = require('node:fs')
+const { resolve } = require('node:path')
+const meow = require('meow')
+const sort = require('sort-keys')
 
-const { createReadStream, createWriteStream } = require('fs')
-const { resolve } = require('path')
-const meow = require('meow');
-const sort = require('sort-keys');
-
-const cli = meow({
-  flags: {
-    deep: {
-      type: 'boolean',
-      alias: 'd',
-      default: false
-    },
-    std: {
-      type: 'boolean',
-      alias: 's',
-      default: false
-    }
-  }
-}, `
+const cli = meow(
+	{
+		flags: {
+			deep: {
+				type: 'boolean',
+				alias: 'd',
+				default: false,
+			},
+			std: {
+				type: 'boolean',
+				alias: 's',
+				default: false,
+			},
+		},
+	},
+	`
 	Usage
 	  $ sort-keys <source>[ <destination>]
 	Options
 	  -d, --deep    Deep sort all objects
-    -s, --std.    Use STDIN and STDOUT instead of files
+      -s, --std     Use STDIN and STDOUT instead of files
 	<source>        Source JSON file (if not using STDIN)
 	<destination>   (Optional) Destination file location (if not using STDOUT). Will overwrite source if not provided.
 	Examples
@@ -34,72 +34,60 @@ const cli = meow({
 
     Sort all keys in a JSON file using STDIN and STDOUT
     $ cat example.json | sort-keys -s --deep | sponge example.json
-`);
-
-const checkSuffix = (filename) => 
-  !filename.endsWith('.json') ? `${filename}.json` : filename
+`,
+)
 
 const getSource = (cli) => {
-  if (!!cli.flags.std) {
-    return process.stdin
-  }
+	if (cli.flags.std === true) {
+		return process.stdin
+	}
 
-  let [ source ] = cli.input
-
-  source = resolve(process.cwd(), checkSuffix(source))
-
-  return createReadStream(source, { encoding: "utf-8" })
+	let [source] = cli.input
+	source = resolve(process.cwd(), source)
+	return createReadStream(source, { encoding: 'utf-8' })
 }
 
 const getDestination = (cli) => {
-  if (!!cli.flags.std) {
-    return process.stdout
-  }
+	if (cli.flags.std === true) {
+		return process.stdout
+	}
 
-  let [ _, destination ] = cli.input
-
-  destination = resolve(process.cwd(), checkSuffix(destination))
-
-  return createWriteStream(destination, { encoding: "utf-8" })
+	let [_, destination] = cli.input
+	destination = resolve(process.cwd(), destination)
+	return createWriteStream(destination, { encoding: 'utf-8' })
 }
 
 const readJSON = (stream) => {
-  let data = []
-
-  stream.setEncoding("utf-8")
-
-  return new Promise((resolve, reject) => {
-    stream.on("error", reject)
-
-    stream.on("data", (chunk) => data.push(chunk))
-
-    stream.on("end", () => {
-      try {
-        resolve(JSON.parse(data.join("")))
-      }
-      catch(e) {
-        reject(e)
-      }
-    })
-  })
+	const data = []
+	stream.setEncoding('utf-8')
+	return new Promise((resolve, reject) => {
+		stream.on('error', reject)
+		stream.on('data', (chunk) => data.push(chunk))
+		stream.on('end', () => {
+			try {
+				resolve(JSON.parse(data.join('')))
+			} catch (e) {
+				reject(e)
+			}
+		})
+	})
 }
-  
-(async () => {
-  try {
-    const source = getSource(cli)
-    const obj = await readJSON(source)
-    const sorted = sort(obj, {
-      deep: !!cli.flags.deep,
-    });
+;(async () => {
+	try {
+		const source = getSource(cli)
+		const obj = await readJSON(source)
+		const sorted = sort(obj, {
+			deep: !!cli.flags.deep,
+		})
 
-    const destination = getDestination(cli)
-    destination.write(JSON.stringify(sorted, null, 2))
-  } catch (error) {
-    if (error.name === 'SortKeysError') {
-      console.error(error.message);
-      process.exit(1);
-    } else {
-      throw error;
-    }
-  }
-})();
+		const destination = getDestination(cli)
+		destination.write(JSON.stringify(sorted, null, 2))
+	} catch (error) {
+		if (error.name === 'SortKeysError') {
+			console.error(error.message)
+			process.exit(1)
+		} else {
+			throw error
+		}
+	}
+})()

--- a/cli.test.js
+++ b/cli.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const { writeFileSync, readFileSync, unlinkSync } = require('node:fs')
+const path = require('node:path')
+
+const CLI_PATH = path.resolve(__dirname, 'cli.js')
+
+/**
+ * Creates a temporary file with specified content.
+ * Returns the file path and a cleanup function.
+ *
+ * @param {string} prefix - File name prefix.
+ * @param {string} content - Content to write in the file.
+ * @returns {{filePath: string, cleanup: () => void}}
+ */
+function createTempFile(prefix, content) {
+	const filePath = path.resolve(__dirname, `${prefix}-${Date.now()}.tmp`)
+	writeFileSync(filePath, content, 'utf-8')
+
+	return {
+		filePath,
+		cleanup: () => unlinkSync(filePath),
+	}
+}
+
+/** Helper to run the CLI command */
+function runCli(args, input = null) {
+	return spawnSync('node', [CLI_PATH, ...args], {
+		input,
+		encoding: 'utf-8',
+	})
+}
+
+test('should sort json files', () => {
+	const input = JSON.stringify({ z: 1, a: 2 })
+	const expectedOutput = JSON.stringify({ a: 2, z: 1 }, null, 2)
+
+	const inputFile = createTempFile('input', input)
+	const outputFile = createTempFile('output', '') // Empty output file
+
+	runCli([inputFile.filePath, outputFile.filePath])
+
+	const outputData = readFileSync(outputFile.filePath, 'utf-8')
+	assert.equal(outputData, expectedOutput)
+
+	inputFile.cleanup()
+	outputFile.cleanup()
+})
+
+test('should not sort non-json files', () => {
+	const inputFile = createTempFile('input', 'Not a JSON file')
+	const outputFile = createTempFile('output', '')
+
+	const result = runCli([inputFile.filePath, outputFile.filePath])
+
+	assert.equal(result.status, 1)
+	assert.match(result.stderr, /Unexpected token/)
+
+	inputFile.cleanup()
+	outputFile.cleanup()
+})
+
+test('should sort json stdin', () => {
+	const inputData = JSON.stringify({ z: 1, a: 2 })
+	const expectedOutput = JSON.stringify({ a: 2, z: 1 }, null, 2)
+
+	const result = runCli(['--std'], inputData)
+
+	assert.equal(result.status, 0)
+	assert.equal(result.stdout.trim(), expectedOutput)
+})
+
+test('should not sort non-json stdin', () => {
+	const inputData = 'Not a JSON string'
+
+	const result = runCli(['--std'], inputData)
+
+	assert.equal(result.status, 1)
+	assert.match(result.stderr, /Unexpected token/)
+})

--- a/input.txt
+++ b/input.txt
@@ -1,0 +1,1 @@
+Not a JSON file

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "sort-keys": "cli.js"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=18"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "npx @biomejs/biome check *.js",
+    "lint:fix": "npx @biomejs/biome check --write *.js",
+    "test": "node --test cli.test.js"
   },
   "files": [
     "cli.js"
@@ -34,5 +36,9 @@
   "dependencies": {
     "meow": "^6.0.1",
     "sort-keys": "^4.0.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "1.9.4",
+    "@types/node": "^22.10.7"
   }
 }


### PR DESCRIPTION
I use the `sort-keys` CLI tool a lot, however I often want to use it as part of a pipeline of JSON processing. I use [jq](https://jqlang.github.io/jq/) or custom JSON processing scripts that process JSON to STDIN and STDOUT.

Rather then write my own CLI tool around `sort-keys` I’m contributing this PR so that other users of the tool will be able to benefit.

It’s backwards compatible as the feature has to be opted into (with the `-s` flag).

I have tested it with the following JSON (`example.json`)

```json
{
  "d": {
    "z": 6,
    "y": 5,
    "x": 4
  },
  "c": 3,
  "b": 2,
  "a": 1
}
```

```shell
$ sort-keys -d example.json example2.json
$ cat example.json | sort-keys -s -d > example3.json
$ diff example2.json example3.json
```